### PR TITLE
fix: update release tagging preference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           images: |
             name=ghcr.io/thin-edge/tedge-mqtt-broker
           tags: |
-            type=semver,pattern={{version}}
+            type=ref,event=tag
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ thin-edge.io specific MQTT broker (using tedge-mqtt-broker) container which incl
 
 ## Development
 
+All of the tasks in the projects use [just](https://github.com/casey/just). Please install just before using any of the instructions.
+
+### Trigger a new release
+
+1. Switch to the main branch (on the main repo)
+
+2. Run the release task
+
+    ```sh
+    just release
+    ```
+
+    The task will create a git tag and push it to the configured remote origin.
+
 ### Run and validate a local mqtt broker
 
 You can run/start a local container with the MQTT broker by using [just](https://github.com/casey/just) task runner.


### PR DESCRIPTION
Fix the release workflow to use the given tag as the container tag, and add instructions on how a developer can publish a new release.