### PR TITLE
fix: use custom entrypoint to fix permissions before starting mosquitto

### DIFF
--- a/src/mosquitto/Dockerfile
+++ b/src/mosquitto/Dockerfile
@@ -19,6 +19,9 @@ LABEL org.opencontainers.image.base.name="alpine:3.18"
 
 VOLUME /etc/tedge/mosquitto-conf
 
+COPY entrypoint.sh /entrypoint.sh
 COPY mosquitto.conf /mosquitto/config/mosquitto.conf
 COPY tedge-mosquitto.conf /etc/tedge/mosquitto-conf/
+
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]

--- a/src/mosquitto/entrypoint.sh
+++ b/src/mosquitto/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Fix mosquitto permissions (pulled from mosquitto's own dockerfile)
+user="$(id -u)"
+if [ "$user" = "0" ]; then
+	if [ -d /mosquitto ]; then
+        # Use the gid and uid instead of the name
+        chown -R "1883:1883" /mosquitto || true
+    fi
+	if [ -d /etc/tedge/device-certs/ ]; then
+        chown -R "1883:1883" /etc/tedge/device-certs/ || true
+    fi
+fi
+
+exec "$@"


### PR DESCRIPTION
Change permissions of thin-edge.io device certificates and mosquitto config file before starting.